### PR TITLE
Restrict to GHC >= 7.2

### DIFF
--- a/cf.cabal
+++ b/cf.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules: Math.ContinuedFraction,
                    Math.ContinuedFraction.Simple,
                    Math.ContinuedFraction.Interval
-  build-depends:       base >= 4 && < 5
+  build-depends:       base >= 4.4 && < 5
   default-language:    Haskell2010
 
 test-suite tests


### PR DESCRIPTION
Build error on 7.0:

```
src/Math/ContinuedFraction.hs:40:10:
    Illegal instance declaration for `HasFractionField Rational'
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use -XTypeSynonymInstances if you want to disable this.)
    In the instance declaration for `HasFractionField Rational'
```

I've revised this on hackage so a new release is only needed if you wish to add compatibility for older GHCs. https://hackage.haskell.org/package/cf-0.4.1/revisions/

Build matrix: http://matrix.hackage.haskell.org/package/cf#GHC-7.0/cf-0.4.1
